### PR TITLE
fix default timeout of 5min

### DIFF
--- a/ultima_scraper_api/managers/session_manager.py
+++ b/ultima_scraper_api/managers/session_manager.py
@@ -146,9 +146,11 @@ class SessionManager:
         )
         final_cookies = self.get_cookies()
         # Had to remove final_cookies and cookies=final_cookies due to it conflicting with headers
+        timeout = aiohttp.ClientTimeout(total=None, connect=10, sock_connect=10, sock_read=30)
         client_session = ClientSession(
             connector=connector,
             cookies=final_cookies,
+            timeout=timeout
         )
         return client_session
 


### PR DESCRIPTION
The default timeout from `aiohttp` prevents any download to exceed 5min which make it impossible if bandwidth and size of the file make it impossible to be downloaded within the 5min limit.

See https://docs.aiohttp.org/en/stable/client_quickstart.html#timeouts for reference.

This PR disables the `total` timeout and checks if data is received continuously instead.